### PR TITLE
don't mutate data passed in to constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,6 @@ function AbstractError(klass) {
 
     if (data && data.errors) {
       errors = data.errors;
-      delete data.errors;
     }
 
     // NOTE (EK): Babel doesn't support this so


### PR DESCRIPTION
otherwise throws an error if data is immutable (e.g. frozen with `Object.freeze`)