### PR TITLE
adding an explicit error type

### DIFF
--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -19,7 +19,7 @@ export default function(options = {}) {
   }
 
   return function(error, req, res, next) {
-    if ( !(error instanceof errors.FeathersError) ) {
+    if (error.type !== 'FeathersError') {
       let oldError = error;
       error = new errors.GeneralError(oldError.message, {
         errors: oldError.errors

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ class FeathersError extends Error {
     // NOTE (EK): Babel doesn't support this so
     // we have to pass in the class name manually.
     // this.name = this.constructor.name;
+    this.type = 'FeathersError';
     this.name = name;
     this.message = message;
     this.code = code;


### PR DESCRIPTION
We need this because for some reason, in some cases errors seems to not be instances of a `FeathersError` so they were always getting wrapped as a General Error. Using `instanceof` comparison is flakey using babel anyway so we're setting an explicit `FeathersError` type now. Closes #27.