### PR TITLE
Custom handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,12 @@
     "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",
+    "chai": "^3.5.0",
     "feathers": "^2.0.0",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -10,7 +10,7 @@ const defaultError = path.resolve(defaults.public, 'default.html');
 export default function(options = {}) {
   options = Object.assign({}, defaults, options);
   
-  if(typeof options.html === 'undefined') {
+  if (typeof options.html === 'undefined') {
     options.html = {
       401: path.resolve(options.public, '401.html'),
       404: path.resolve(options.public, '404.html'),
@@ -30,38 +30,63 @@ export default function(options = {}) {
       }
     }
 
-    const code = !isNaN( parseInt(error.code, 10) ) ? parseInt(error.code, 10) : 500;
+    error.code = !isNaN( parseInt(error.code, 10) ) ? parseInt(error.code, 10) : 500;
     const formatter = {};
 
-    if(options.html) {
+    // If the developer passed a custom function
+    if (typeof options.html === 'function') {
+      formatter['text/html'] = options.html;
+    }
+    else {
       formatter['text/html'] = function() {
-        let file = options.html[code];
+        let file = options.html[error.code];
         
-        if(!file) {
+        if (!file) {
           file = options.html.default || defaultError;
         }
         
+        res.set('Content-Type', 'text/html');
         res.sendFile(file);
       };
     }
-    
-    formatter['application/json'] = function () {
-      let output = Object.assign({}, error.toJSON());
 
-      if (process.env.NODE_ENV === 'production') {
-        delete output.stack;
+    // If the developer passed a custom function
+    if (typeof options.json === 'function') {
+      formatter['application/json'] = options.json;
+    }
+    else {
+      // Don't show stack trace if it is a 404 error
+      if (error.code === 404) {
+        error.stack = null;
       }
 
-      res.json(output);
-    };
-    
-    // Don't show stack trace if it is a 404 error
-    if (code === 404) {
-      error.stack = null;
+      formatter['application/json'] = function () {
+        let output = Object.assign({}, error.toJSON());
+
+        if (process.env.NODE_ENV === 'production') {
+          delete output.stack;
+        }
+
+        res.set('Content-Type', 'application/json');
+        res.json(output);
+      };
     }
 
-    res.status(code);
+    res.status(error.code);
 
-    res.format(formatter);
+    const contentType = req.headers['content-type'] || '';
+    const accepts = req.headers.accept || '';
+
+    // by default just send back json
+    if (contentType.indexOf('json') !== -1 || accepts.indexOf('json') !== -1) {
+      formatter['application/json'](error, req, res, next);
+    }
+    else if ( options.html && (contentType.indexOf('html') !== -1 || accepts.indexOf('html') !== -1) ) {
+      return formatter['text/html'](error, req, res, next);
+    }
+    else {
+      // TODO (EK): Maybe just return plain text
+      formatter['application/json'](error, req, res, next);
+    }
   };
 }

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -82,7 +82,13 @@ describe('feathers-errors', () => {
     describe('text/html format', () => {
       it('serves a 404.html', done => {
         fs.readFile(join(__dirname, '..', 'src', 'public', '404.html'), function(err, html) {
-          request('http://localhost:5050/path/to/nowhere', (error, res, body) => {
+          request({
+            url: 'http://localhost:5050/path/to/nowhere',
+            headers: {
+              'Content-Type': 'text/html',
+              'Accept': 'text/html'
+            }
+          }, (error, res, body) => {
             assert.equal(res.statusCode, 404);
             assert.equal(html.toString(), body);
             done();
@@ -92,8 +98,44 @@ describe('feathers-errors', () => {
 
       it('serves a 500.html', done => {
         fs.readFile(join(__dirname, '..', 'src', 'public', 'default.html'), function(err, html) {
-          request('http://localhost:5050/error', (error, res, body) => {
+          request({
+            url: 'http://localhost:5050/error',
+            headers: {
+              'Content-Type': 'text/html',
+              'Accept': 'text/html'
+            }
+          }, (error, res, body) => {
             assert.equal(res.statusCode, 500);
+            assert.equal(html.toString(), body);
+            done();
+          });
+        });
+      });
+
+      it('returns html when Content-Type header is set', done => {
+        fs.readFile(join(__dirname, '..', 'src', 'public', '404.html'), function(err, html) {
+          request({
+            url: 'http://localhost:5050/path/to/nowhere',
+            headers: {
+              'Content-Type': 'text/html'
+            }
+          }, (error, res, body) => {
+            assert.equal(res.statusCode, 404);
+            assert.equal(html.toString(), body);
+            done();
+          });
+        });
+      });
+
+      it('returns html when Accept header is set', done => {
+        fs.readFile(join(__dirname, '..', 'src', 'public', '404.html'), function(err, html) {
+          request({
+            url: 'http://localhost:5050/path/to/nowhere',
+            headers: {
+              'Accept': 'text/html'
+            }
+          }, (error, res, body) => {
+            assert.equal(res.statusCode, 404);
             assert.equal(html.toString(), body);
             done();
           });
@@ -105,6 +147,10 @@ describe('feathers-errors', () => {
       it('500', done => {
         request({
           url: 'http://localhost:5050/error',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
           json: true
         }, (error, res, body) => {
           assert.equal(res.statusCode, 500);
@@ -123,6 +169,10 @@ describe('feathers-errors', () => {
       it('404', done => {
         request({
           url: 'http://localhost:5050/path/to/nowhere',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
           json: true
         }, (error, res, body) => {
           assert.equal(res.statusCode, 404);
@@ -139,6 +189,10 @@ describe('feathers-errors', () => {
       it('400', done => {
         request({
           url: 'http://localhost:5050/bad-request',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
           json: true
         }, (error, res, body) => {
           assert.equal(res.statusCode, 400);
@@ -157,6 +211,81 @@ describe('feathers-errors', () => {
           });
           done();
         });
+      });
+
+      it('returns JSON when only Content-Type header is set', done => {
+        request({
+          url: 'http://localhost:5050/bad-request',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          json: true
+        }, (error, res, body) => {
+          assert.equal(res.statusCode, 400);
+          assert.deepEqual(body, { name: 'BadRequest',
+            message: 'Invalid Password',
+            code: 400,
+            className: 'bad-request',
+            data: {
+              message: 'Invalid Password'
+            },
+            errors: [{
+              path: 'password',
+              value: null,
+              message: `'password' cannot be 'null'`
+            }]
+          });
+          done();
+        });
+      });
+
+      it('returns JSON when only Accept header is set', done => {
+        request({
+          url: 'http://localhost:5050/bad-request',
+          headers: {
+            'Accept': 'application/json'
+          },
+          json: true
+        }, (error, res, body) => {
+          assert.equal(res.statusCode, 400);
+          assert.deepEqual(body, { name: 'BadRequest',
+            message: 'Invalid Password',
+            code: 400,
+            className: 'bad-request',
+            data: {
+              message: 'Invalid Password'
+            },
+            errors: [{
+              path: 'password',
+              value: null,
+              message: `'password' cannot be 'null'`
+            }]
+          });
+          done();
+        });
+      });
+    });
+
+    it('returns JSON by default', done => {
+      request('http://localhost:5050/bad-request', (error, res, body) => {
+        const expected = JSON.stringify({
+          name: 'BadRequest',
+          message: 'Invalid Password',
+          code: 400,
+          className: 'bad-request',
+          data: {
+            message: 'Invalid Password'
+          },
+          errors: [{
+            path: 'password',
+            value: null,
+            message: `'password' cannot be 'null'`
+          }]
+        });
+
+        assert.equal(res.statusCode, 400);
+        assert.deepEqual(body, expected);
+        done();
       });
     });
   });


### PR DESCRIPTION
This PR does a couple things:

- converts over to chai for tests
- adds better support for detecting `content-type` and `accepts` headers
- makes JSON the default response
- adds support for passing a custom html handler
- adds support for passing a custom json handler