### PR TITLE
Not found

### DIFF
--- a/not-found.js
+++ b/not-found.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/not-found-handler');

--- a/src/not-found-handler.js
+++ b/src/not-found-handler.js
@@ -1,0 +1,7 @@
+import errors from './index';
+
+export default function() {
+  return function(req, res, next) {
+    next(new errors.NotFound('Page not found'));
+  };
+}

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -24,7 +24,7 @@ const jsonHandler = sinon.spy(function(error, req, res, next) {
   res.json(error);
 });
 
-describe('feathers-errors', () => {
+describe('error-handler', () => {
   it('is CommonJS compatible', () => {
     expect(typeof require('../lib/error-handler')).to.equal('function');
   });

--- a/test/not-found-handler.test.js
+++ b/test/not-found-handler.test.js
@@ -1,0 +1,34 @@
+/*jshint expr: true, unused: false*/
+
+if(!global._babelPolyfill) { require('babel-polyfill'); }
+
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { errors } from '../src';
+import handler from '../src/not-found-handler';
+
+chai.use(sinonChai);
+
+const mockRequest = {};
+const mockResponse = {};
+const mockNext = sinon.spy(() => {});
+
+describe('not-found-handler', () => {
+  it('is CommonJS compatible', () => {
+    expect(typeof require('../lib/not-found-handler')).to.equal('function');
+  });
+
+  it('can be required at the root', () => {
+    expect(typeof require('../not-found')).to.equal('function');
+  });
+
+  it('is import compatible', () => {
+    expect(typeof handler).to.equal('function');
+  });
+
+  it('returns NotFound error', () => {
+    handler()(mockRequest, mockResponse, mockNext);
+    expect(mockNext).to.have.been.calledWith(new errors.NotFound());
+  });
+});


### PR DESCRIPTION
Adding back a really basic not found handler. This makes a bit more sense now that we are generating more standalone services. You don't want to have to create a separate middleware for every single service when you are already requiring feathers-errors.