### PR TITLE
Change default value of errors to be an array ( for consistency )

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class FeathersError extends Error {
     this.code = code;
     this.className = className;
     this.data = newData;
-    this.errors = errors || {};
+    this.errors = errors || [];
 
     debug(`${this.name}(${this.code}): ${this.message}`);
   }

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -124,7 +124,8 @@ describe('error-handler', () => {
           next(e);
         })
         .get('/bad-request', function (req, res, next) {
-          next(new errors.BadRequest({
+          next(new 
+               .BadRequest({
             message: 'Invalid Password',
             errors: [{
               path: 'password',
@@ -158,7 +159,7 @@ describe('error-handler', () => {
             code: 500,
             className: 'general-error',
             data: {},
-            errors: {}
+            errors: []
           });
           done();
         });
@@ -250,7 +251,7 @@ describe('error-handler', () => {
             code: 500,
             className: 'general-error',
             data: {},
-            errors: {}
+            errors: []
           });
           done();
         });
@@ -270,7 +271,7 @@ describe('error-handler', () => {
             message: 'File not found',
             code: 404,
             className: 'not-found',
-            errors: {}
+            errors: []
           });
           done();
         });

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable handle-callback-err  */
 if (!global._babelPolyfill) { require('babel-polyfill'); }
 
-import feathers from 'feathers';
+import feathers from 'feathers';e
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -101,7 +101,7 @@ describe('error-handler', () => {
           code: 500,
           className: 'general-error',
           data: {},
-          errors: {}
+          errors: []
         });
         request(options, (error, res, body) => {
           expect(body).to.deep.equal(expected);


### PR DESCRIPTION
For a consistent response the errors should always be an array.