### PR TITLE
change errors default type to Array instead of object, for consistent…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class FeathersError extends Error {
     this.code = code;
     this.className = className;
     this.data = newData;
-    this.errors = errors || {};
+    this.errors = errors || [];
 
     debug(`${this.name}(${this.code}): ${this.message}`);
   }

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -101,7 +101,7 @@ describe('error-handler', () => {
           code: 500,
           className: 'general-error',
           data: {},
-          errors: {}
+          errors: []
         });
         request(options, (error, res, body) => {
           expect(body).to.deep.equal(expected);
@@ -158,7 +158,7 @@ describe('error-handler', () => {
             code: 500,
             className: 'general-error',
             data: {},
-            errors: {}
+            errors: []
           });
           done();
         });
@@ -250,7 +250,7 @@ describe('error-handler', () => {
             code: 500,
             className: 'general-error',
             data: {},
-            errors: {}
+            errors: []
           });
           done();
         });
@@ -270,7 +270,7 @@ describe('error-handler', () => {
             message: 'File not found',
             code: 404,
             className: 'not-found',
-            errors: {}
+            errors: []
           });
           done();
         });


### PR DESCRIPTION
When the errors is empty it returns an object as response, which is inconsistent, since it always returns an array of objects ( when it has errors )