### PR TITLE
Fix compile npm task on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
     "changelog": "github_changelog_generator && git add CHANGELOG.md && git commit -am \"Updating changelog\"",
-    "compile": "rimraf lib/ && babel -d lib/ src/ && mkdir lib/public/ && cp src/public/* lib/public/",
+    "compile": "shx rm -rf lib/ && babel -d lib/ src/ && shx mkdir lib/public/ && shx cp src/public/* lib/public/",
     "watch": "babel --watch -d lib/ src/",
     "lint": "eslint-if-supported semistandard --fix",
     "mocha": "mocha --opts mocha.opts",
@@ -67,8 +67,8 @@
     "feathers": "^2.0.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.0.0",
+    "shx": "~0.2.1",
     "request": "^2.69.0",
-    "rimraf": "^2.5.4",
     "semistandard": "^9.1.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"


### PR DESCRIPTION
Add portable shell commands to avoid problems with rm, mkdir, cp, ... in whatever machine with nodejs

