### PR TITLE
fix pull request #62

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,8 +65,8 @@ declare namespace FeathersErrors {
 }
 
 declare namespace FeathersErrors  {
-  types: FeathersErrors;
-  function convert(error: any):FeathersError;
+  types: FeathersErrors
+  function convert(error: any):FeathersError
   errors: FeathersErrors
 }
 


### PR DESCRIPTION
this shoul fix:

```
Compiling...
Using tsc v2.2.1
node_modules/feathers-errors/index.d.ts(68,3): error TS1036: Statements are not allowed in ambient contexts.
node_modules/feathers-errors/index.d.ts(68,3): error TS7028: Unused label.
node_modules/feathers-errors/index.d.ts(70,3): error TS7028: Unused label.
```