### PR TITLE
Change back to old Error inheritance

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,4 @@
 {
-  "plugins": [
-    "transform-object-assign",
-    "add-module-exports",
-    ["babel-plugin-transform-builtin-extend", { globals: ["Error", "Array"] }]
-  ],
+  "plugins": [ "transform-object-assign", "add-module-exports" ],
   "presets": [ "es2015" ]
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.17",
-    "babel-plugin-add-module-exports": "^0.2.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,6 @@
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.17",
     "babel-plugin-add-module-exports": "^0.2.0",
-    "babel-plugin-transform-builtin-extend": "^1.1.0",
-    "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.5.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
 import { types, errors, convert } from '../src';
 
-if (!global._babelPolyfill) { require('babel-polyfill'); }
-
 describe('feathers-errors', () => {
   it('is CommonJS compatible', () => {
     assert.equal(typeof require('../lib'), 'object');

--- a/test/not-found-handler.test.js
+++ b/test/not-found-handler.test.js
@@ -1,5 +1,4 @@
 import chai, { expect } from 'chai';
-import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { errors } from '../src';
 import handler from '../src/not-found-handler';
@@ -7,10 +6,6 @@ import handler from '../src/not-found-handler';
 if (!global._babelPolyfill) { require('babel-polyfill'); }
 
 chai.use(sinonChai);
-
-const mockRequest = {};
-const mockResponse = {};
-const mockNext = sinon.spy(() => {});
 
 describe('not-found-handler', () => {
   it('is CommonJS compatible', () => {
@@ -25,8 +20,10 @@ describe('not-found-handler', () => {
     expect(typeof handler).to.equal('function');
   });
 
-  it.skip('returns NotFound error', () => {
-    handler()(mockRequest, mockResponse, mockNext);
-    expect(mockNext).to.have.been.calledWith(new errors.NotFound());
+  it('returns NotFound error', done => {
+    handler()({}, {}, function (error) {
+      expect(error instanceof errors.NotFound).to.equal(true);
+      done();
+    });
   });
 });


### PR DESCRIPTION
Babel class extension of built-in types is causing a whole host of issues with older browsers (especially IE <= 10 which does not allow extending built-in types which basically broke feathers-client but only when an error ocurred) but also other environments (like React native).

I am suggesting to go back to old school JavaScript inheritance and avoid all those problems. From the test it seems to be fully backwards compatible.