### PR TITLE
Fix errors property being lost when cloning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,11 @@ function FeathersError (msg, name, code, className, data) {
     if (newData.errors) {
       errors = newData.errors;
       delete newData.errors;
+    } else if (data.errors) {
+      // The errors property from data could be
+      // stripped away while cloning resulting newData not to have it
+      // For example: when cloning arrays this property
+      errors = JSON.parse(JSON.stringify(data.errors));
     }
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -299,6 +299,7 @@ describe('feathers-errors', () => {
       assert.equal(error.data.errors, undefined);
       assert.ok(Array.isArray(error.data));
       assert.deepEqual(error.data, [{hello: 'world'}]);
+      assert.equal(error.errors, 'Invalid input');
     });
   });
 });


### PR DESCRIPTION
### Summary

This issue was introduced in 2.8.0 when #75 was merged.
Now we allow data to be an array, but in the cloning process, the `errors` property gets lost.
Sorry for overlooking this in my previous PR. :broken_heart: 