### PR TITLE
Add more information to error debug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ function FeathersError (msg, name, code, className, data) {
   this.errors = errors || {};
 
   debug(`${this.name}(${this.code}): ${this.message}`);
+  debug(this.errors);
 }
 
 FeathersError.prototype = new Error();


### PR DESCRIPTION
Currently, there is very little information on an error caught by feathers-errors even when DEBUG is on. This pull request writes additional details.

As an example, when there is an unique violation error from the database, Sequelize throws a Validation error. Currently, feathers-errors logs the following kind of message with debug on:

    feathers-errors BadRequest(400): Validation error +0ms

which is kind of vague and it is hard to tell what caused the error.
After this update, the message looks like:

    feathers-errors BadRequest(400): Validation error +0ms
    feathers-errors [ ValidationErrorItem {
    feathers-errors     message: 'email must be unique',
    feathers-errors     type: 'unique violation',
    feathers-errors     path: 'email',
    feathers-errors     value: 'some@email.com' } ] +0ms