### PR TITLE
Add back default error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 const debug = require('debug')('feathers-errors');
 
 function FeathersError (msg, name, code, className, data) {
+  msg = msg || 'Error';
+
   let errors;
   let message;
   let newData;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -184,6 +184,7 @@ describe('feathers-errors', () => {
         var error = new errors.GeneralError();
         assert.equal(error.code, 500);
         assert.equal(error.className, 'general-error');
+        assert.equal(error.message, 'Error');
         assert.notEqual(error.stack, undefined);
         assert.equal(error instanceof errors.GeneralError, true);
         assert.equal(error instanceof errors.FeathersError, true);


### PR DESCRIPTION
This was removed in #82 but is at least breaking https://github.com/feathersjs/feathers-authentication-management/issues/60

Adding it back since it doesn't really relate to the actual fix.