### PR TITLE
Refactor out an interpolated string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function FeathersError (msg, name, code, className, data) {
   this.data = newData;
   this.errors = errors || {};
 
-  debug(`${this.name}(${this.code}): ${this.message}`);
+  debug(this.name + '(' + this.code + '): ' + this.message);
   debug(this.errors);
 
   if (Error.captureStackTrace) {


### PR DESCRIPTION
Refactor out an interpolated string being passed to a call to `debug`. This is to that when requiring client-side packages such as `@feathersjs/rest-client` and `@feathersjs/authentication-client` and loading the bundled code in IE 11 we don't get any invalid token errors (i.e. interpolated strings are not supported by IE 11).